### PR TITLE
Changed repository from which docker will be pulled

### DIFF
--- a/ops/terraform/tagger-service-provsioning/modules/setup/kubernetes_module/leader/setup.sh.tfemplate
+++ b/ops/terraform/tagger-service-provsioning/modules/setup/kubernetes_module/leader/setup.sh.tfemplate
@@ -8,7 +8,7 @@ sudo apt-get install -y \
     software-properties-common
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 sudo add-apt-repository \
-   "deb https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") \
+   "deb [arch=amd64] https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") \
    $(lsb_release -cs) \
    stable"
 sudo apt-get update && sudo apt-get install -y docker-ce=$(apt-cache madison docker-ce | grep 17.03 | head -1 | awk '{print $3}')

--- a/ops/terraform/tagger-service-provsioning/modules/setup/kubernetes_module/setup.sh.tfemplate
+++ b/ops/terraform/tagger-service-provsioning/modules/setup/kubernetes_module/setup.sh.tfemplate
@@ -8,7 +8,7 @@ sudo apt-get install -y \
     software-properties-common
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 sudo add-apt-repository \
-   "deb https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") \
+   "deb [arch=amd64] https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") \
    $(lsb_release -cs) \
    stable"
 sudo apt-get update && sudo apt-get install -y docker-ce=$(apt-cache madison docker-ce | grep 17.03 | head -1 | awk '{print $3}')


### PR DESCRIPTION
The problem was:
When initially installing Docker a different repository (actually the repository is the same, but it was added differently into /etc/apt/sources.list) was used than when TerraForm installed Docker. The quick fix is: Adapt the repository from which to install Docker.